### PR TITLE
Add around callback

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -31,6 +31,27 @@ The gem will look for a `AnythingSteps` in the `app/steps` directory
 and run the `some_event` method, changing the object status of
 `MyClass` from `:initial` to `:final`.
 
+### Add callbacks
+
+- `around`: called around each transition
+- `after_processes`: called at the end of the workflow
+
+```ruby
+class MyClass
+  include ProcessSpecification
+
+  after_processes do |instance|
+    puts 'All is done'
+  end
+
+  around do |transition, instance, block|
+    logger.tagged transition[:method] do
+      logger.info "Going from #{instance.status} to #{transition[:target]}"
+      block.call
+    end
+  end
+end
+```
 
 Contributors
 ------------

--- a/Rakefile
+++ b/Rakefile
@@ -4,5 +4,3 @@ Bundler::GemHelper.install_tasks
 require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new
 
-require 'cucumber/rake/task'
-Cucumber::Rake::Task.new(:features)

--- a/lib/bpmachine/process_specification.rb
+++ b/lib/bpmachine/process_specification.rb
@@ -1,13 +1,5 @@
 module BPMachine
   module ProcessSpecification
-    def self.after_processes(&block)
-      after_process_actions << block
-    end
-
-    def self.after_process_actions
-      @after_process_actions ||= []
-    end
-
     def self.included(klass)
       klass.extend ClassMethods
     end
@@ -34,8 +26,8 @@ module BPMachine
     end
 
     def execute_global_after_actions
-      ProcessSpecification.after_process_actions.each do |action|
-        action.call(self)
+      self.class.after_process_actions.each do |action|
+        action.call self
       end
     end
 
@@ -55,6 +47,14 @@ module BPMachine
             execute_global_after_actions
           end
         end
+      end
+
+      def after_processes(&block)
+        after_process_actions << block
+      end
+
+      def after_process_actions
+        @after_process_actions ||= []
       end
 
       private

--- a/lib/bpmachine/process_specification.rb
+++ b/lib/bpmachine/process_specification.rb
@@ -20,9 +20,13 @@ module BPMachine
         transition = specification.transition_for state
         return state if transition.nil?
         return state unless (transition[:if].nil? || self.send(transition[:if]))
-        self.send transition[:method]
+        call_around(transition) { self.send transition[:method] }
         change_status transition[:target]
       end
+    end
+
+    def call_around(transition, &block)
+      self.class.around_block.call(transition, self, block)
     end
 
     def execute_global_after_actions
@@ -55,6 +59,14 @@ module BPMachine
 
       def after_process_actions
         @after_process_actions ||= []
+      end
+
+      def around(&block)
+        @around_block = block
+      end
+
+      def around_block
+        @around_block ||= -> (_transition, _instance, block) { block.call }
       end
 
       private

--- a/spec/bpmachine_spec.rb
+++ b/spec/bpmachine_spec.rb
@@ -219,7 +219,7 @@ describe "the DSL for business process" do
     machine.should_receive :erase_data
     machine.uninstall
 
-    called.should be_true
+    called.should be_truthy
   end
 
   it "should raise error when model can't be saved" do
@@ -240,8 +240,8 @@ describe "the DSL for business process" do
 
     process = TheProcess.new
     process.status = :initial
-    process.stub!(:some_event)
-    process.stub!(:other_event)
+    allow(process).to receive(:some_event)
+    allow(process).to receive(:other_event)
     lambda { process.anything }.should raise_error("Big Error!")
   end
 

--- a/spec/bpmachine_spec.rb
+++ b/spec/bpmachine_spec.rb
@@ -3,11 +3,11 @@ require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 describe "the DSL for business process" do
   describe "automatic module loading" do
     it "should require a file named <process_name>_steps.rb if exists" do
-      Object.should be_const_defined(:UninstallSteps)
+      expect(Object).to be_const_defined(:UninstallSteps)
     end
 
     it "should include the steps definition module named <Process>Steps in the process declaring class" do
-      Machine.included_modules.should include(UninstallSteps)
+      expect(Machine.included_modules).to include(UninstallSteps)
     end
 
     it "should ignore step definition files that doesn't exist" do
@@ -19,7 +19,7 @@ describe "the DSL for business process" do
           end
         end
       end
-      declaration.should_not raise_error
+      expect { declaration }.not_to raise_error
     end
 
     it "should ignore step definition files that doesn't exist" do
@@ -31,8 +31,8 @@ describe "the DSL for business process" do
           end
         end
       end
-      Kernel.should_receive(:puts).with(/WrongSteps/)
-      declaration.should_not raise_error
+      expect(Kernel).not_to receive(:puts).with(/WrongSteps/)
+      expect { declaration }.not_to raise_error
     end
 
   end
@@ -40,19 +40,19 @@ describe "the DSL for business process" do
   it "should execute all transitions described in the process" do
     machine = Machine.new
     machine.status = :deactivated
-    machine.should_receive(:machine_exists?).and_return true
-    machine.should_receive :remove_disks
-    machine.should_receive :destroy_vm
-    machine.should_receive :erase_data
+    expect(machine).to receive(:machine_exists?).and_return true
+    expect(machine).to receive(:remove_disks)
+    expect(machine).to receive(:destroy_vm)
+    expect(machine).to receive(:erase_data)
 
     machine.uninstall
-    machine.status.should == :uninstalled
+    expect(machine.status).to eq :uninstalled
   end
 
   it "should not change state if condition fails" do
   	machine = Machine.new
   	machine.status = :deactivated
-  	machine.should_receive(:machine_exists?).and_return false
+  	expect(machine).to receive(:machine_exists?).and_return false
 
   	machine.uninstall
   	machine.status = :deactivated
@@ -61,19 +61,19 @@ describe "the DSL for business process" do
   it "should stop execution when a transition fail" do
     machine = Machine.new
     machine.status = :deactivated
-    machine.should_receive(:machine_exists?).and_return true
-    machine.should_receive :remove_disks
-    machine.should_receive(:destroy_vm).and_raise("execution fail")
+    expect(machine).to receive(:machine_exists?).and_return true
+    expect(machine).to receive(:remove_disks)
+    expect(machine).to receive(:destroy_vm).and_raise("execution fail")
 
-    lambda { machine.uninstall }.should raise_error("execution fail")
-    machine.status.should == :diskless
+    expect { machine.uninstall }.to raise_error("execution fail")
+    expect(machine.status).to eq :diskless
   end
 
   it "should require the initial state" do
     machine = Machine.new
     machine.status = :activated
 
-    lambda { machine.uninstall }.should raise_error(InvalidInitialState,
+    expect { machine.uninstall }.to raise_error(InvalidInitialState,
         "Process uninstall requires object to have initial status deactivated or any transitional status, but it is activated")
   end
 
@@ -81,57 +81,57 @@ describe "the DSL for business process" do
     machine = Machine.new
     machine.status = :activated
 
-    machine.should_receive(:create_disks)
+    expect(machine).to receive(:create_disks)
     machine.install
   end
 
   it "should not accept unexpected stated" do
     machine = Machine.new
     machine.status = :deactivated
-    lambda { machine.install }.should raise_error(InvalidInitialState,
+    expect { machine.install }.to raise_error(InvalidInitialState,
         "Process install requires object to have initial status initial_status or any transitional status, but it is deactivated")
   end
 
   it "should execute subprocess" do
     machine = Machine.new
     machine.status = :ready_for_subprocess
-    machine.should_receive(:step1).ordered
-    machine.should_receive(:step2).ordered
-    machine.should_receive(:step3).ordered
+    expect(machine).to receive(:step1).ordered
+    expect(machine).to receive(:step2).ordered
+    expect(machine).to receive(:step3).ordered
     machine.execute_with_subprocess
-    machine.status.should == :all_done
+    expect(machine.status).to eq :all_done
   end
 
   it "should resume a process stopped in a subprocess" do
     machine = Machine.new
     machine.status = :step1_done
-    machine.should_not_receive(:step1)
-    machine.should_receive(:step2).ordered
-    machine.should_receive(:step3).ordered
+    expect(machine).not_to receive(:step1)
+    expect(machine).to receive(:step2).ordered
+    expect(machine).to receive(:step3).ordered
     machine.execute_with_subprocess
-    machine.status.should == :all_done
+    expect(machine.status).to eq :all_done
   end
 
   it "should allow the process to resume from a transitional state" do
     machine = Machine.new
     machine.status = :diskless
-    machine.should_not_receive(:remove_disks)
-    machine.should_receive(:destroy_vm).ordered
-    machine.should_receive(:erase_data).ordered
+    expect(machine).not_to receive(:remove_disks)
+    expect(machine).to receive(:destroy_vm).ordered
+    expect(machine).to receive(:erase_data).ordered
     machine.uninstall
-    machine.status.should == :uninstalled
+    expect(machine.status).to eq :uninstalled
   end
 
   it "should be case insensitive with status" do
     machine = Machine.new
     machine.status = :deactivated
-    machine.should_receive(:machine_exists?).ordered.and_return true
-    machine.should_receive(:remove_disks).ordered
-    machine.should_receive(:destroy_vm).ordered
-    machine.should_receive(:erase_data).ordered
+    expect(machine).to receive(:machine_exists?).ordered.and_return true
+    expect(machine).to receive(:remove_disks).ordered
+    expect(machine).to receive(:destroy_vm).ordered
+    expect(machine).to receive(:erase_data).ordered
 
     machine.uninstall
-    machine.status.should == :uninstalled
+    expect(machine.status).to eq :uninstalled
   end
 
   it "should support custom code to be run before process start" do
@@ -152,8 +152,8 @@ describe "the DSL for business process" do
 
     process = ProcessWithBeforeAction.new
     process.status = :initial
-    process.should_receive(:do_action).ordered
-    process.should_receive(:some_event).ordered
+    expect(process).to receive(:do_action).ordered
+    expect(process).to receive(:some_event).ordered
     process.anything
   end
 
@@ -170,8 +170,8 @@ describe "the DSL for business process" do
 
     process = ProcessWithBeforeAction.new
     process.status = :initial
-    process.should_receive(:some_event).ordered
-    process.should_receive(:do_action).ordered
+    expect(process).to receive(:some_event).ordered
+    expect(process).to receive(:do_action).ordered
     process.anything
   end
 
@@ -192,15 +192,15 @@ describe "the DSL for business process" do
 
     process = InitialStateNotRequired.new
     process.status = :initial
-    process.should_receive :some_event
+    expect(process).to receive(:some_event)
     process.anything
-    process.status.should == :final
+    expect(process.status).to eq :final
 
     second_process = InitialStateNotRequired.new
     second_process.status = :other
-    second_process.should_receive :other_event
+    expect(second_process).to receive(:other_event)
     second_process.anything
-    second_process.status.should == :final
+    expect(second_process.status).to eq :final
   end
 
   it "should accept global 'after' blocks, passing the object processing the flow" do
@@ -209,17 +209,17 @@ describe "the DSL for business process" do
     called = false
     ProcessSpecification.after_processes do |process_object|
       called = true
-      process_object.should be(machine)
+      expect(process_object).to be(machine)
     end
 
     machine.status = :deactivated
-    machine.should_receive(:machine_exists?).and_return true
-    machine.should_receive :remove_disks
-    machine.should_receive :destroy_vm
-    machine.should_receive :erase_data
+    expect(machine).to receive(:machine_exists?).and_return true
+    expect(machine).to receive(:remove_disks)
+    expect(machine).to receive(:destroy_vm)
+    expect(machine).to receive(:erase_data)
     machine.uninstall
 
-    called.should be_truthy
+    expect(called).to be_truthy
   end
 
   it "should raise error when model can't be saved" do
@@ -242,7 +242,7 @@ describe "the DSL for business process" do
     process.status = :initial
     allow(process).to receive(:some_event)
     allow(process).to receive(:other_event)
-    lambda { process.anything }.should raise_error("Big Error!")
+    expect { process.anything }.to raise_error("Big Error!")
   end
 
 end

--- a/spec/bpmachine_spec.rb
+++ b/spec/bpmachine_spec.rb
@@ -224,6 +224,32 @@ describe "the DSL for business process" do
     expect(machine.process_object).to be(machine)
   end
 
+  describe "should accept 'around' blocks" do
+    let(:machine) do
+      c = Class.new(Machine) do
+        around do |_transition, instance, block|
+          instance.begin_around
+          block.call
+          instance.end_around
+        end
+      end
+
+      c.new.tap { |m| m.status = :deactivated }
+    end
+
+    it 'runs the workflow with the around block' do
+      expect(machine).to receive(:machine_exists?).and_return true
+      expect(machine).to receive(:remove_disks)
+      expect(machine).to receive(:destroy_vm)
+      expect(machine).to receive(:erase_data)
+
+      expect(machine).to receive(:begin_around).exactly(3).times
+      expect(machine).to receive(:end_around).exactly(3).times
+
+      machine.uninstall
+    end
+  end
+
   it "should raise error when model can't be saved" do
     class TheProcess
       include ProcessSpecification


### PR DESCRIPTION
To do something like

```ruby
class MyClass
  include ProcessSpecification

  around do |transition, instance, block|
    logger.tagged transition[:method] do
      logger.info "Going from #{instance.status} to #{transition[:target]}"
      block.call
    end
  end
end
```

Also:
- Fix/improve specs
- Fix a collateral effect of `after_processes` method to not impact all classes that use `ProcessSpecification`